### PR TITLE
修改 travis-ci 的配置

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,6 @@ script:
 os:
   - linux
   - windows
+matrix:
+  allow_failures:
+    - os: windows


### PR DESCRIPTION
修改 travis-ci 的配置为 忽略 Windows 的 Build 结果，因为目前似乎
travis-ci 的 Windows环境不支持 C#